### PR TITLE
feat/swagger-ui: Add Swagger UI

### DIFF
--- a/server/discussion-forum-service/README.md
+++ b/server/discussion-forum-service/README.md
@@ -1,0 +1,20 @@
+# discussion-forum
+
+## Getting Started
+Below is documentation for using the discussion forum service:
+1. You need to install MongoDB locally, follow this: https://www.mongodb.com/docs/manual/installation/ (and follow MongoDB Community Edition)
+2. Run the MongoDB daemon for your OS (as per instructions in the docs above) (this part is highly OS specific and may take time to setup)
+3. Create a new collection and name it “Discussion-Forum”
+4. Create a `.env.local` file with: `MONGODB_CONNECTION="mongodb://127.0.0.1:27017/Discussion-Forum"`
+5. To start the server,
+    1. `npm i` - to install
+    2. `npm run dev` - to run the local test server
+6. If you want to test the production database, you can replace the `.env.local` file with `MONGODB_CONNECTION="<PRODUCTION-DB-URL>"` - THIS IS NOT RECOMMENDED
+
+At the same time you also need to create a `.env` file with `MONGODB_CONNECTION="<PRODUCTION-DB-URL>"`. The purpose of two separate environment files is to make sure that locally (when you are testing) you do not modify the production database.
+
+## Testing
+To run tests against the API on a local MongoDB instanc
+1. Start the server with `npm run dev`
+2. You can run automated tests for `/api/posts` and `/api/comments`, with `npm run test`.
+3. You can also explore the API with Swagger UI by going to [localhost:5001/api-docs](http://localhost:5001/api-docs/)

--- a/server/discussion-forum-service/package-lock.json
+++ b/server/discussion-forum-service/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "^16.4.7",
         "express": "^4.18.2",
         "mongoose": "^8.10.1",
+        "swagger-ui-express": "^5.0.1",
         "uuid": "^11.0.5"
       },
       "devDependencies": {
@@ -21,6 +22,7 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^18.11.10",
         "@types/supertest": "^6.0.2",
+        "@types/swagger-ui-express": "^4.1.8",
         "@types/uuid": "^10.0.0",
         "jest": "^29.7.0",
         "nodemon": "^2.0.22",
@@ -1187,6 +1189,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1496,6 +1505,17 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/uuid": {
@@ -5520,6 +5540,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.20.0.tgz",
+      "integrity": "sha512-V5pozVTZxivdoQq/SQWxj3A4cOu5opk9MEbcZANX3Pj8X8xCrD1QCtBT7744Pz9msOvt0nnmy9JvM/9PGonCdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/test-exclude": {

--- a/server/discussion-forum-service/package.json
+++ b/server/discussion-forum-service/package.json
@@ -19,6 +19,7 @@
     "dotenv": "^16.4.7",
     "express": "^4.18.2",
     "mongoose": "^8.10.1",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^11.0.5"
   },
   "devDependencies": {
@@ -27,6 +28,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^18.11.10",
     "@types/supertest": "^6.0.2",
+    "@types/swagger-ui-express": "^4.1.8",
     "@types/uuid": "^10.0.0",
     "jest": "^29.7.0",
     "nodemon": "^2.0.22",

--- a/server/discussion-forum-service/src/app.ts
+++ b/server/discussion-forum-service/src/app.ts
@@ -2,6 +2,8 @@ import express from "express";
 import cors from "cors";
 import postRoutes from "./routes/posts.routes";
 import commentRoutes from "./routes/comments.routes";
+import swaggerUi from "swagger-ui-express";
+import openApiSpec from "../swagger.json";
 
 const app = express();
 app.use(cors());
@@ -9,5 +11,5 @@ app.use(express.json());
 
 app.use("/api", postRoutes);
 app.use("/api", commentRoutes);
-
+app.use("/api-docs/", swaggerUi.serve, swaggerUi.setup(openApiSpec));
 export default app;

--- a/server/discussion-forum-service/swagger.json
+++ b/server/discussion-forum-service/swagger.json
@@ -1,0 +1,347 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Discussion Forum API",
+    "description": "CRUD API for creating discussion forum posts and comments",
+    "version": "0.0.1"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:5001",
+      "description": "Localhost testing server"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "Post": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "MongoDB-assigned ID"
+          },
+          "user_id": {
+            "type": "string",
+            "description": "ID of the user who created the post"
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the post"
+          },
+          "content": {
+            "type": "string",
+            "description": "Content of the post"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Tags associated with the post"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the post was created"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the post was last updated"
+          },
+          "likes": {
+            "type": "integer",
+            "description": "Number of likes the post has received"
+          },
+          "comments_count": {
+            "type": "integer",
+            "description": "Number of comments on the post"
+          }
+        }
+      },
+      "CreatePostRequest": {
+        "type": "object",
+        "required": ["user_id", "title", "content"],
+        "properties": {
+          "user_id": {
+            "type": "string",
+            "description": "ID of the user creating the post"
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the post"
+          },
+          "content": {
+            "type": "string",
+            "description": "Content of the post"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Tags associated with the post"
+          }
+        }
+      },
+      "UpdatePostRequest": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Updated title of the post"
+          },
+          "content": {
+            "type": "string",
+            "description": "Updated content of the post"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Updated tags associated with the post"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/posts": {
+      "get": {
+        "summary": "Returns all posts ever created",
+        "responses": {
+          "200": {
+            "description": "A JSON array of posts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Post"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePostRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Creates and returns the created post",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Post"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error, required content missing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/posts/{id}": {
+      "get": {
+        "summary": "Returns a post, given a post-id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the created post",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Post is not found, ID is likely incorrect",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Updates a post by the post-id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePostRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Post is updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Post"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Post is not found, ID is likely incorrect",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a post by the post-id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Post is deleted"
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/posts/user/{id}": {
+      "get": {
+        "summary": "Returns all of a user's post, by the user's id",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the user's posts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Post"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Posts are not found, user ID is likely incorrect",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/server/discussion-forum-service/tsconfig.json
+++ b/server/discussion-forum-service/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
+    "resolveJsonModule": true,
     "esModuleInterop": true
   },
   "exclude": [


### PR DESCRIPTION
# Swagger UI
Created the initial OpenAPI spec for Swagger UI for `/api/posts` and setup the Swagger UI.

## How to Run

1. `npm run dev` to start the server
2. Visit `localhost:5001/api-docs`

Note: please follow the README to add the environment specific files required.

## TODO
- Write more documentation on how to run the local MongoDB instance for testing
- Write `/api/comments` OpenAPI spec